### PR TITLE
several bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGES
 
-## next version
+## v1.0.0
   - doc improvements
+  - several bugfixes regarding finite elements defined on subgrids
+  - integrate now reacts on regions parameter and has proper docstrings
 
 ## v0.8.1 November 5, 2024
   - fixed dimension in nodevals output (xdim was determined wrongly and caused huge arrays)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableFEMBase"
 uuid = "12fb9182-3d4c-4424-8fd1-727a0899810c"
 authors = ["Christian Merdon <merdon@wias-berlin.de>"]
-version = "0.8.1"
+version = "1.0.0"
 
 [deps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/src/fedefs/h1_p3.jl
+++ b/src/fedefs/h1_p3.jl
@@ -201,8 +201,8 @@ function get_basis(::Type{<:AssemblyType}, ::Type{H1P3{ncomponents, edim}}, ::Ty
 end
 
 # we need to change the ordering of the face dofs on faces that have a negative orientation sign
-function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P3{ncomponents, edim}, APT}, EG::Type{<:Triangle2D}) where {ncomponents, edim, Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P3{ncomponents, edim}, APT}, EG::Type{<:Triangle2D}, xgrid) where {ncomponents, edim, Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     return function closure(subset_ids::Array{Int, 1}, cell)
         for j in 1:nfaces
@@ -223,8 +223,8 @@ function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P3{ncomponents,
 end
 
 # we need to change the ordering of the face dofs on faces that have a negative orientation sign
-function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P3{ncomponents, edim}, APT}, EG::Type{<:Tetrahedron3D}) where {ncomponents, edim, Tv, Ti, APT}
-    xCellEdgeSigns = FE.dofgrid[CellEdgeSigns]
+function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P3{ncomponents, edim}, APT}, EG::Type{<:Tetrahedron3D}, xgrid) where {ncomponents, edim, Tv, Ti, APT}
+    xCellEdgeSigns = xgrid[CellEdgeSigns]
     nedges::Int = num_edges(EG)
     return function closure(subset_ids::Array{Int, 1}, cell)
         for j in 1:nedges

--- a/src/fedefs/h1_pk.jl
+++ b/src/fedefs/h1_pk.jl
@@ -290,11 +290,11 @@ end
 
 
 ## if order > 2 on Triangl2D we need to change the ordering of the face dofs on faces that have a negative orientation sign
-function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1Pk{ncomponents, edim, order}, APT}, EG::Type{<:Triangle2D}) where {ncomponents, edim, order, Tv, Ti, APT}
+function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1Pk{ncomponents, edim, order}, APT}, EG::Type{<:Triangle2D}, xgrid) where {ncomponents, edim, order, Tv, Ti, APT}
     if order < 3
         return NothingFunction # no reordering needed
     end
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     ndofs_for_f::Int = order - 1
     ndofs_for_c = get_ndofs(ON_CELLS, H1Pk{1, edim, order}, EG)

--- a/src/fedefs/h1v_br.jl
+++ b/src/fedefs/h1v_br.jl
@@ -148,9 +148,9 @@ function get_basis(AT::Type{ON_CELLS}, FEType::Type{H1BR{2}}, EG::Type{<:Quadril
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Triangle2D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
-    xCellFaces = FE.dofgrid[CellFaces]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Triangle2D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
+    xCellFaces = xgrid[CellFaces]
     return function closure(coefficients::Array{<:Real, 2}, cell)
         fill!(coefficients, 1.0)
         coefficients[1, 7] = xFaceNormals[1, xCellFaces[1, cell]]
@@ -162,9 +162,9 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, :
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Quadrilateral2D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
-    xCellFaces = FE.dofgrid[CellFaces]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Quadrilateral2D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
+    xCellFaces = xgrid[CellFaces]
     return function closure(coefficients::Array{<:Real, 2}, cell)
         fill!(coefficients, 1.0)
         coefficients[1, 9] = xFaceNormals[1, xCellFaces[1, cell]]
@@ -178,8 +178,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, :
     end
 end
 
-function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Edge1D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
+function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{2}, APT}, ::Type{<:Edge1D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
     return function closure(coefficients::Array{<:Real, 2}, face)
         # multiplication of face bubble with normal vector of face
         fill!(coefficients, 1.0)
@@ -253,9 +253,9 @@ function get_basis(AT::Type{ON_CELLS}, ::Type{H1BR{3}}, EG::Type{<:Hexahedron3D}
 end
 
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Tetrahedron3D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
-    xCellFaces::Adjacency{Ti} = FE.dofgrid[CellFaces]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Tetrahedron3D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
+    xCellFaces::Adjacency{Ti} = xgrid[CellFaces]
     return function closure(coefficients::Array{<:Real, 2}, cell)
         # multiplication with normal vectors
         fill!(coefficients, 1.0)
@@ -276,8 +276,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, :
 end
 
 
-function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Triangle2D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
+function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Triangle2D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
     return function closure(coefficients::Array{<:Real, 2}, face)
         # multiplication of face bubble with normal vector of face
         fill!(coefficients, 1.0)
@@ -287,9 +287,9 @@ function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{3}, APT},
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Hexahedron3D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
-    xCellFaces::Adjacency{Ti} = FE.dofgrid[CellFaces]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Hexahedron3D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
+    xCellFaces::Adjacency{Ti} = xgrid[CellFaces]
     return function closure(coefficients::Array{<:Real, 2}, cell)
         # multiplication with normal vectors
         fill!(coefficients, 1.0)
@@ -316,8 +316,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, :
 end
 
 
-function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Quadrilateral2D}) where {Tv, Ti, APT}
-    xFaceNormals::Array{Tv, 2} = FE.dofgrid[FaceNormals]
+function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1BR{3}, APT}, ::Type{<:Quadrilateral2D}, xgrid) where {Tv, Ti, APT}
+    xFaceNormals::Array{Tv, 2} = xgrid[FaceNormals]
     return function closure(coefficients::Array{<:Real, 2}, face)
         # multiplication of face bubble with normal vector of face
         fill!(coefficients, 1.0)

--- a/src/fedefs/h1v_p1teb.jl
+++ b/src/fedefs/h1v_p1teb.jl
@@ -253,9 +253,9 @@ function get_basis(AT::Type{ON_CELLS}, ::Type{H1P1TEB{3}}, EG::Type{<:Tetrahedro
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P1TEB{3}, APT}, ::Type{<:Tetrahedron3D}) where {Tv, Ti, APT}
-    xEdgeTangents::Array{Tv, 2} = FE.dofgrid[EdgeTangents]
-    xCellEdges = FE.dofgrid[CellEdges]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P1TEB{3}, APT}, ::Type{<:Tetrahedron3D}, xgrid) where {Tv, Ti, APT}
+    xEdgeTangents::Array{Tv, 2} = xgrid[EdgeTangents]
+    xCellEdges = xgrid[CellEdges]
     return function closure(coefficients::Array{<:Real, 2}, cell)
         fill!(coefficients, 1.0)
         for e in 1:6, k in 1:2
@@ -265,9 +265,9 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, H1P1TEB{3}, APT}
     end
 end
 
-function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1P1TEB{3}, APT}, ::Type{<:Triangle2D}) where {Tv, Ti, APT}
-    xEdgeTangents::Array{Tv, 2} = FE.dofgrid[EdgeTangents]
-    xFaceEdges = FE.dofgrid[FaceEdges]
+function get_coefficients(::Type{<:ON_FACES}, FE::FESpace{Tv, Ti, H1P1TEB{3}, APT}, ::Type{<:Triangle2D}, xgrid) where {Tv, Ti, APT}
+    xEdgeTangents::Array{Tv, 2} = xgrid[EdgeTangents]
+    xFaceEdges = xgrid[FaceEdges]
     return function closure(coefficients::Array{<:Real, 2}, face)
         fill!(coefficients, 1.0)
         for e in 1:3, k in 1:2

--- a/src/fedefs/hcurl_n0.jl
+++ b/src/fedefs/hcurl_n0.jl
@@ -144,8 +144,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HCURLN0{3}}, ::Type{<:Tetrahedron3D}
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN0, APT}, EG::Type{<:AbstractElementGeometry2D}) where {Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN0, APT}, EG::Type{<:AbstractElementGeometry2D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces = num_faces(EG)
     return function closure(coefficients, cell)
         # multiplication with normal vector signs
@@ -156,8 +156,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN0, APT},
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN0, APT}, EG::Type{<:AbstractElementGeometry3D}) where {Tv, Ti, APT}
-    xCellEdgeSigns = FE.dofgrid[CellEdgeSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN0, APT}, EG::Type{<:AbstractElementGeometry3D}, xgrid) where {Tv, Ti, APT}
+    xCellEdgeSigns = xgrid[CellEdgeSigns]
     nedges = num_edges(EG)
     return function closure(coefficients, cell)
         # multiplication with normal vector signs

--- a/src/fedefs/hcurl_n1.jl
+++ b/src/fedefs/hcurl_n1.jl
@@ -104,8 +104,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HCURLN1{2}}, ::Type{<:Triangle2D})
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN1, APT}, EG::Type{<:AbstractElementGeometry2D}) where {Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HCURLN1, APT}, EG::Type{<:AbstractElementGeometry2D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces = num_faces(EG)
     return function closure(coefficients, cell)
         # multiplication with normal vector signs (only RT0)

--- a/src/fedefs/hdiv_bdm1.jl
+++ b/src/fedefs/hdiv_bdm1.jl
@@ -203,8 +203,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HDIVBDM1{3}}, ::Type{<:Tetrahedron3D
 end
 
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry2D}) where {Tv, Ti, APT}
-    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry2D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     dim::Int = dim_element(EG)
     return function closure(coefficients::Array{<:Real, 2}, cell::Int)

--- a/src/fedefs/hdiv_bdm1.jl
+++ b/src/fedefs/hdiv_bdm1.jl
@@ -218,9 +218,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}
 end
 
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry3D}) where {Tv, Ti, APT}
-    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = FE.dofgrid[CellFaceSigns]
-    xCellFaceOrientations::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = FE.dofgrid[CellFaceOrientations]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry3D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     dim::Int = dim_element(EG)
     return function closure(coefficients::Array{<:Real, 2}, cell::Int)
@@ -238,8 +237,8 @@ end
 # the RT0 and those two BDM1 face functions are chosen
 # such that they reflect the two moments with respect to the second and third node
 # of the global face enumeration
-function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry3D}) where {Tv, Ti, APT}
-    xCellFaceOrientations = FE.dofgrid[CellFaceOrientations]
+function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM1, APT}, EG::Type{<:AbstractElementGeometry3D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceOrientations = xgrid[CellFaceOrientations]
     nfaces::Int = num_faces(EG)
     orientation = xCellFaceOrientations[1, 1]
     shift4orientation1::Array{Int, 1} = [1, 0, 1, 2]

--- a/src/fedefs/hdiv_bdm2.jl
+++ b/src/fedefs/hdiv_bdm2.jl
@@ -206,8 +206,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HDIVBDM2{2}}, ::Type{<:Triangle2D})
 end
 
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM2, APT}, EG::Type{<:AbstractElementGeometry2D}) where {Tv, Ti, APT}
-    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVBDM2, APT}, EG::Type{<:AbstractElementGeometry2D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     dim::Int = dim_element(EG)
     return function closure(coefficients::Array{<:Real, 2}, cell::Int)

--- a/src/fedefs/hdiv_bdm2.jl
+++ b/src/fedefs/hdiv_bdm2.jl
@@ -66,7 +66,7 @@ function ExtendableGrids.interpolate!(Target::AbstractArray{T, 1}, FE::FESpace{T
     xCellDofs::DofMapTypes{Ti} = FE[CellDofs]
     qf = QuadratureRule{T, EG}(max(4, 2 + bonus_quadorder))
     FEB = FEEvaluator(FE, Identity, qf; T = T)
-    QP = QPInfos(FE.dofgrid)
+    QP = QPInfos(FE.dofgrid; kwargs...)
 
     # evaluation of gradient of P1 functions
     FE3 = H1P1{1}

--- a/src/fedefs/hdiv_rt0.jl
+++ b/src/fedefs/hdiv_rt0.jl
@@ -117,8 +117,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HDIVRT0{3}}, ::Type{<:Hexahedron3D})
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT0, APT}, EG::Type{<:AbstractElementGeometry}) where {Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT0, APT}, EG::Type{<:AbstractElementGeometry}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces = num_faces(EG)
     return function closure(coefficients, cell)
         # multiplication with normal vector signs

--- a/src/fedefs/hdiv_rt1.jl
+++ b/src/fedefs/hdiv_rt1.jl
@@ -198,8 +198,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HDIVRT1{3}}, ::Type{<:Tetrahedron3D}
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{2}, APT}, EG::Type{<:Triangle2D}) where {Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{2}, APT}, EG::Type{<:Triangle2D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces = num_faces(EG)
     return function closure(coefficients, cell)
         fill!(coefficients, 1.0)
@@ -211,8 +211,8 @@ function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{2}, AP
     end
 end
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{3}, APT}, EG::Type{<:Tetrahedron3D}) where {Tv, Ti, APT}
-    xCellFaceSigns = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{3}, APT}, EG::Type{<:Tetrahedron3D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceSigns = xgrid[CellFaceSigns]
     nfaces = num_faces(EG)
     return function closure(coefficients, cell)
         fill!(coefficients, 1.0)
@@ -232,8 +232,8 @@ end
 # the RT0 and those two BDM1 face functions are chosen
 # such that they reflect the two moments with respect to the second and third node
 # of the global face enumeration
-function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{3}, APT}, EG::Type{<:Tetrahedron3D}) where {Tv, Ti, APT}
-    xCellFaceOrientations = FE.dofgrid[CellFaceOrientations]
+function get_basissubset(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRT1{3}, APT}, EG::Type{<:Tetrahedron3D}, xgrid) where {Tv, Ti, APT}
+    xCellFaceOrientations = xgrid[CellFaceOrientations]
     nfaces::Int = num_faces(EG)
     orientation = xCellFaceOrientations[1, 1]
     shift4orientation1::Array{Int, 1} = [1, 0, 1, 2]

--- a/src/fedefs/hdiv_rtk.jl
+++ b/src/fedefs/hdiv_rtk.jl
@@ -76,7 +76,7 @@ function ExtendableGrids.interpolate!(Target::AbstractArray{T, 1}, FE::FESpace{T
     xCellDofs::DofMapTypes{Ti} = FE[CellDofs]
     qf = QuadratureRule{T, EG}(max(2 * order, order + 1 + bonus_quadorder))
     FEB = FEEvaluator(FE, Identity, qf; T = T)
-    QP = QPInfos(FE.dofgrid)
+    QP = QPInfos(FE.dofgrid; kwargs...)
 
     # evaluation of gradient of P1 functions
     FE3 = order == 1 ? L2P0{ncomponents} : H1Pk{ncomponents, 2, order - 1}

--- a/src/fedefs/hdiv_rtk.jl
+++ b/src/fedefs/hdiv_rtk.jl
@@ -208,8 +208,8 @@ function get_basis(::Type{ON_CELLS}, ::Type{HDIVRTk{2, order}}, ::Type{<:Triangl
 end
 
 
-function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRTk{2, order}, APT}, EG::Type{<:Triangle2D}) where {Tv, Ti, APT, order}
-    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = FE.dofgrid[CellFaceSigns]
+function get_coefficients(::Type{ON_CELLS}, FE::FESpace{Tv, Ti, <:HDIVRTk{2, order}, APT}, EG::Type{<:Triangle2D}, xgrid) where {Tv, Ti, APT, order}
+    xCellFaceSigns::Union{VariableTargetAdjacency{Int32}, Array{Int32, 2}} = xgrid[CellFaceSigns]
     nfaces::Int = num_faces(EG)
     dim::Int = dim_element(EG)
     return function closure(coefficients::Array{<:Real, 2}, cell::Int)

--- a/src/feevaluator.jl
+++ b/src/feevaluator.jl
@@ -90,11 +90,11 @@ function FEEvaluator(
     coeff_handler = NothingFunction
     if FEType <: Union{AbstractH1FiniteElementWithCoefficients, AbstractHdivFiniteElement, AbstractHcurlFiniteElement}
         coefficients = ones(T, ncomponents, ndofs4item)
-        coeff_handler = get_coefficients(FEAT, FE, EG)
+        coeff_handler = get_coefficients(FEAT, FE, EG, xgrid)
     end
 
     # set subset handler (only relevant if ndofs4item_all > ndofs4item)
-    subset_handler = get_basissubset(FEAT, FE, EG)
+    subset_handler = get_basissubset(FEAT, FE, EG, xgrid)
 
     # prepare offsets and additional coefficients
     offsets = 0:edim:((ncomponents - 1) * edim) # edim steps

--- a/src/feevaluator.jl
+++ b/src/feevaluator.jl
@@ -178,7 +178,7 @@ _prepare_additional_coefficients(::Type{<:AbstractFunctionOperator}, xgrid, AT, 
 _prepare_additional_coefficients(::Type{<:NormalFlux}, xgrid, AT, edim) = AT == ON_BFACES ? view(xgrid[FaceNormals], :, xgrid[BFaceFaces]) : xgrid[FaceNormals]
 _prepare_additional_coefficients(::Type{<:TangentialGradient}, xgrid, AT, edim) = xgrid[FaceNormals]
 function _prepare_additional_coefficients(::Type{<:TangentFlux}, xgrid, AT, edim)
-    if edim == 2
+    if edim == 1
         return _prepare_additional_coefficients(NormalFlux, xgrid, AT, edim)
     else
         return AT == ON_BEDGES ? view(xgrid[EdgeTangents], :, xgrid[BEdgeEdges]) : xgrid[EdgeTangents]

--- a/src/feevaluator.jl
+++ b/src/feevaluator.jl
@@ -43,14 +43,14 @@ Note that matrix-valued operators evaluations, e.g. for Gradient, are given as a
 function FEEvaluator(
         FE::FESpace{TvG, TiG, FEType, FEAPT},
         operator::Type{<:StandardFunctionOperator},
-        qrule::QuadratureRule{TvR, EG};
+        qrule::QuadratureRule{TvR, EG},
+        xgrid = FE.dofgrid;     # FE.xgrid also reasonable in certain situations
         L2G = nothing,
         T = Float64,
         AT = ON_CELLS
     ) where {TvG, TiG, TvR, FEType <: AbstractFiniteElement, EG <: AbstractElementGeometry, FEAPT <: AssemblyType}
 
     xref = qrule.xref
-    xgrid = FE.xgrid
     if L2G === nothing
         L2G = L2GTransformer(EG, xgrid, AT)
     end
@@ -76,7 +76,7 @@ function FEEvaluator(
         end
     end
     edim = max(1, dim_element(EG))
-    xdim = size(FE.xgrid[Coordinates], 1)
+    xdim = size(xgrid[Coordinates], 1)
     resultdim = Int(Length4Operator(operator, edim, ncomponents))
 
     # evaluate basis on reference domain
@@ -104,8 +104,8 @@ function FEEvaluator(
         @warn "ndofs = 0 for FEType = $FEType on EG = $EG"
         offsets2 = []
     end
-    compressiontargets = _prepare_compressiontargets(operator, FE.xgrid, AT, edim)
-    coefficients_op = _prepare_additional_coefficients(operator, FE.xgrid, AT, edim)
+    compressiontargets = _prepare_compressiontargets(operator, xgrid, AT, edim)
+    coefficients_op = _prepare_additional_coefficients(operator, xgrid, AT, edim)
     current_eval = zeros(T, resultdim, ndofs4item, length(xref))
 
     derivorder = NeededDerivative4Operator(operator)

--- a/src/feevaluator_h1.jl
+++ b/src/feevaluator_h1.jl
@@ -158,6 +158,21 @@ function update_basis!(FEBE::SingleFEEvaluator{<:Real, <:Real, <:Integer, <:Norm
     return nothing
 end
 
+
+# TANGENTFLUX H1 (ON_FACES, ON_BFACES)
+function update_basis!(FEBE::SingleFEEvaluator{<:Real, <:Real, <:Integer, <:TangentFlux, <:AbstractH1FiniteElement})
+    # fetch normal of item
+    normal = view(FEBE.coefficients_op, :, FEBE.citem[])
+    subset = _update_subset!(FEBE)
+    cvals = FEBE.cvals
+    refbasisvals = FEBE.refbasisvals
+    fill!(cvals, 0)
+    for i in 1:size(cvals, 3), dof_i in 1:size(cvals, 2), k in 1:length(normal)
+        cvals[1, dof_i, i] = refbasisvals[i][subset[dof_i], 1] * normal[2] - refbasisvals[i][subset[dof_i], 2] * normal[1]
+    end
+    return nothing
+end
+
 # NORMALFLUX H1+COEFFICIENTS (ON_FACES, ON_BFACES)
 function update_basis!(FEBE::SingleFEEvaluator{<:Real, <:Real, <:Integer, <:NormalFlux, <:AbstractH1FiniteElementWithCoefficients})
     # fetch normal of item

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -645,7 +645,22 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Integration that writes result on every item into integral4items.
+Integration of an integrand of the signature
+
+	integrand!(result, qpinfo)
+
+over the entities AT of the grid. The result on every item is written into integral4items.
+As usual, qpinfo allows to access information
+at the current quadrature point.
+The length of the result needs to be specified via resultdim.
+
+Keyword arguments:
+- quadorder = specifies the quadrature order (default = 0)
+- regions = restricts integration to these regions (default = [] meaning all regions)
+- items = restricts integration to these item numbers (default = [] meaning all items)
+- time = sets the time to be passed to qpinfo (default = 0)
+- params = sets the params array to be passed to qpinfo (default = [])
+- offset = offset for writing into result array integral4items (default = [0]),
 """
 function integrate!(
         integral4items::AbstractArray{T},
@@ -655,6 +670,7 @@ function integrate!(
         offset = [0],
         bonus_quadorder = 0,
         quadorder = 0,
+        regions = [],
         time = 0,
         items = [],
         force_quadrature_rule = nothing,
@@ -702,6 +718,14 @@ function integrate!(
         local2global[j] = L2GTransformer(EG[j], grid, AT)
     end
 
+    ## prepare regions
+    visit_region = zeros(Bool, maximum(xItemRegions))
+    if length(regions) > 0
+        visit_region[regions] .= true
+    else
+        visit_region .= true
+    end
+
     # loop over items
     if items == []
         items = 1:nitems
@@ -734,6 +758,16 @@ function integrate!(
 
         fill!(integral4items, 0)
         for item::Int in items
+            if xItemRegions[item] > 0
+                if !(visit_region[xItemRegions[item]]) || AT == ON_IFACES
+                    continue
+                end
+            else
+                if length(regions) > 0
+                    continue
+                end
+            end
+
             # find index for CellType
             if ngeoms > 1
                 itemET = xItemGeometries[item]
@@ -764,6 +798,16 @@ function integrate!(
 
         fill!(integral4items, 0)
         for item::Int in items
+            if xItemRegions[item] > 0
+                if !(visit_region[xItemRegions[item]]) || AT == ON_IFACES
+                    continue
+                end
+            else
+                if length(regions) > 0
+                    continue
+                end
+            end
+
             # find index for CellType
             if ngeoms > 1
                 itemET = xItemGeometries[item]
@@ -779,7 +823,20 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Integration that returns total integral.
+Integration that returns total integral of an integrand of the signature
+
+	integrand!(result, qpinfo)
+
+over the entities AT of the grid. Here, qpinfo allows to access information
+at the current quadrature point.
+The length of the result needs to be specified via resultdim.
+
+Keyword arguments:
+- quadorder = specifies the quadrature order (default = 0)
+- regions = restricts integration to these regions (default = [] meaning all regions)
+- items = restricts integration to these item numbers (default = [] meaning all items)
+- time = sets the time to be passed to qpinfo (default = 0)
+- params = sets the params array to be passed to qpinfo (default = [])
 """
 function integrate(
         grid::ExtendableGrid,

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -649,10 +649,10 @@ Integration of an integrand of the signature
 
 	integrand!(result, qpinfo)
 
-over the entities AT of the grid. The result on every item is written into integral4items.
+over the entities AT of the grid. The result on every item is written into integral4items
+(at least of size nitems x length of result).
 As usual, qpinfo allows to access information
 at the current quadrature point.
-The length of the result needs to be specified via resultdim.
 
 Keyword arguments:
 - quadorder = specifies the quadrature order (default = 0)

--- a/src/reconstructionoperators.jl
+++ b/src/reconstructionoperators.jl
@@ -31,7 +31,8 @@ end
 function FEEvaluator(
         FE::FESpace{TvG, TiG, FEType, FEAPT},
         operator::Type{<:Reconstruct{FETypeReconst, stdop}},
-        qrule::QuadratureRule{TvR, EG};
+        qrule::QuadratureRule{TvR, EG},
+        xgrid = FE.xgrid;
         L2G = nothing,
         T = Float64,
         AT = ON_CELLS
@@ -40,7 +41,6 @@ function FEEvaluator(
     @debug "Creating FEBasisEvaluator for reconstruction of $stdop operator of $FEType into $FETypeReconst on $EG"
 
     ## generate FESpace for reconstruction
-    xgrid = FE.xgrid
     FE2 = FESpace{FETypeReconst}(xgrid)
 
     ## collect dimension information
@@ -62,7 +62,7 @@ function FEEvaluator(
     if L2G === nothing
         L2G = L2GTransformer(EG, xgrid, AT)
     end
-    FEB = FEEvaluator(FE2, stdop, qrule; L2G = L2G, T = T, AT = AT)
+    FEB = FEEvaluator(FE2, stdop, qrule, xgrid; L2G = L2G, T = T, AT = AT)
 
     ## reconstruction coefficient handler
     reconst_handler = ReconstructionHandler(FE, FE2, AT, EG)


### PR DESCRIPTION
-kwargs in RTK and BDM2 interpolators
-regions in integrate methods are recognized + proper dosctrings
-TangentFlux operator for H1 functions
-CellDofsParents for broken spaces should construct correctly now 
-FEEvaluator can use dofgrid (default) instead of xgrid now
-get_coefficients and get_basissubset now have an additional xgrid argument (they need to be available for xgrid or dofgrid depending on the assembly grid)
(last three should fix some issues with Hdiv-FE on subgrids, related to [ExtendableFEM issue #43](https://github.com/WIAS-PDELib/ExtendableFEM.jl/issues/43))